### PR TITLE
Feature/update interview guides

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,13 @@ interview, just say so and skip the rest).
 - [ ] No personal information about the interviewer (name, contact details, LinkedIn)
 - [ ] Nothing identifying about the candidate beyond role and years of experience
 
+### Frontmatter
+
+- [ ] File starts with YAML frontmatter containing `company`, `role`, and `tags`
+- [ ] `company` matches the folder name, or is `"Unknown"` for entries under `Others/`
+- [ ] `topic/` tags come from the fixed 17-topic vocabulary in the README — no invented topics
+- [ ] Tags reflect what the interview actually covered, not every tool you know
+
 ### Placement
 
 - [ ] File is in the correct company folder, or under `Others/` if the company can't be named

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,65 @@
+<!--
+Thanks for contributing an interview experience.
+
+Fill in the details below and tick the checklist. Delete any section that
+doesn't apply (for example, if you're fixing a typo rather than adding a new
+interview, just say so and skip the rest).
+-->
+
+## What's in this PR
+
+<!-- One line: "Adds a DevOps Engineer interview at Acme from March 2026" -->
+
+**Type of change:**
+
+- [ ] New interview write-up
+- [ ] Addition to an existing write-up (more questions from the same interview)
+- [ ] Correction / typo fix
+- [ ] Repo maintenance (tooling, docs, structure)
+
+## Interview details
+
+<!-- Skip this section for corrections and maintenance PRs. -->
+
+| Field | Value |
+| --- | --- |
+| Company | |
+| Role as advertised | |
+| Round(s) covered | <!-- e.g. screening, L2 technical, hiring manager --> |
+| Approximate date | <!-- e.g. March 2026 --> |
+| Years of experience | <!-- the candidate's, if you're comfortable sharing --> |
+| File added | <!-- e.g. Acme/DevOps_Engineer.md --> |
+
+## Checklist
+
+### Content
+
+- [ ] Questions are recorded **as they were actually asked**, not rephrased into polished textbook wording
+- [ ] This is a real interview, not a compiled "top questions" list from elsewhere
+- [ ] No confidential material — no take-home problem statements under NDA, no internal system names, no proprietary architecture details
+- [ ] No personal information about the interviewer (name, contact details, LinkedIn)
+- [ ] Nothing identifying about the candidate beyond role and years of experience
+
+### Placement
+
+- [ ] File is in the correct company folder, or under `Others/` if the company can't be named
+- [ ] Folder name matches the existing convention (underscores for spaces, e.g. `Morgan_Stanley`)
+- [ ] Filename follows `<Role>.md`, numbered if a file for that role already exists (`DevOps_Engineer_2.md`)
+- [ ] An existing file was **not** overwritten or merged into — separate interviews stay in separate files
+
+### Formatting
+
+- [ ] Ran `npx --yes markdownlint-cli2@0.23.2 --fix "**/*.md"` from the repo root
+- [ ] Every code fence has a language tag (```` ```bash ````, ```` ```yaml ````, ```` ```text ````)
+- [ ] Question numbering is intact and sequential — check this by eye after running the fixer
+- [ ] The `Markdown Lint & Format` check passes on this PR
+
+## Anything else
+
+<!--
+Optional. Useful things to mention:
+  - the interview format (live coding, whiteboard, scenario-based, panel)
+  - roughly how long each round ran
+  - whether the questions leaned practical or theoretical
+  - anything that surprised you
+-->

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,79 @@
+name: Markdown Lint & Format
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: markdown-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  MARKDOWNLINT_VERSION: "0.23.2"
+
+jobs:
+  lint:
+    name: Lint changed markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Collect markdown files changed in this PR
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # ACMR: added, copied, modified, renamed — deleted files can't be linted.
+          git diff --name-only --diff-filter=ACMR "origin/${BASE_REF}...HEAD" -- '*.md' > changed.txt
+          COUNT=$(wc -l < changed.txt | tr -d ' ')
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "### Markdown files changed: ${COUNT}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${COUNT}" -gt 0 ]; then
+            sed 's/^/- /' changed.txt >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Lint and format check (markdownlint)
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          # Read-loop rather than mapfile: portable, and keeps paths with spaces intact.
+          FILES=()
+          while IFS= read -r f; do FILES+=("$f"); done < changed.txt
+          npx --yes "markdownlint-cli2@${MARKDOWNLINT_VERSION}" "${FILES[@]}"
+
+      - name: Explain how to fix
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+
+          ---
+          ### How to fix
+
+          Almost everything here auto-fixes. From the repository root:
+
+          \`\`\`bash
+          npx --yes markdownlint-cli2@${MARKDOWNLINT_VERSION} --fix "**/*.md"
+          \`\`\`
+
+          Rules that would rewrite list numbering are disabled in
+          \`.markdownlint-cli2.jsonc\`, so \`--fix\` will not renumber your
+          questions. It only touches whitespace, blank lines, and markdown
+          correctness.
+
+          \`MD040 fenced-code-language\` is the one rule that cannot auto-fix:
+          add a language tag to the code fence, for example \`\`\`bash or
+          \`\`\`text for plain output.
+          EOF

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,37 @@
+{
+  // Lint + format rules for interview-question markdown.
+  //
+  // markdownlint is the ONLY formatter here, on purpose. Prettier was evaluated
+  // and rejected: it renumbers ordered lists, which silently rewrote the
+  // question numbering in 22 of 152 files (one file collapsed 192 numbered
+  // questions to all "1."). In this repo the numbering is content, not style.
+  //
+  // Every rule left enabled below is safe to `--fix` automatically: it only
+  // touches whitespace, blank lines, and markdown correctness.
+  "config": {
+    "default": true,
+
+    // --- Disabled: these rewrite list structure, i.e. the content itself ---
+    "MD029": false, // ol-prefix: would renumber questions
+    "MD030": false, // list-marker-space: churns indentation of every item
+    "MD007": false, // ul-indent: same
+    "MD004": false, // ul-style: bullet char is not worth a repo-wide rewrite
+
+    // --- Disabled: deliberate house style for long-form Q&A ---
+    "MD013": false, // line-length: answers are long-form, wrapping hurts diffs
+    "MD036": false, // no-emphasis-as-heading: **Q:** / **A:** is the style here
+    "MD033": false, // no-inline-html: <details> blocks are used for answers
+    "MD041": false, // first-line-heading: not every fragment starts with an h1
+    "MD024": { "siblings_only": true }, // repeated headings OK across sections
+
+    // --- Enforced (all auto-fixable except MD040) ---
+    // MD012 no-multiple-blanks, MD032 blanks-around-lists, MD034 no-bare-urls,
+    // MD009 trailing-spaces, MD047 single-trailing-newline, MD001
+    // heading-increment, MD040 fenced-code-language, and the rest of defaults.
+  },
+  // NOTE: deliberately no "globs" key. markdownlint-cli2 UNIONS config globs
+  // with the file arguments it is given, so setting it here would make the CI
+  // job lint the whole repo even though it passes only the PR's changed files.
+  // Scope is always controlled by the caller: `markdownlint-cli2 "**/*.md"`.
+  "ignores": ["node_modules/**"]
+}

--- a/AMEX/DevOps_Engineer.md
+++ b/AMEX/DevOps_Engineer.md
@@ -1,3 +1,15 @@
+---
+company: "AMEX"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/amex
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/sre
+---
+
 # AMEX
 
 **YOE---> 3 yrs**

--- a/Accenture/DevOps_Engineer.md
+++ b/Accenture/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Accenture"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/accenture
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/security
+  - topic/databases
+---
+
 # Accenture
 
 **EXP- 6yrs**

--- a/Accenture/DevOps_Engineer.md
+++ b/Accenture/DevOps_Engineer.md
@@ -2,7 +2,6 @@
 
 **EXP- 6yrs**
 
-
 - You have created an IAM user in AWS and configured role-based access in EKS. How do you bind the IAM user to the EKS role?
 - Assume you have 10 AWS accounts. How will you securely log in to them, considering access keys are not used for security reasons?
 - What are the ways to log in to an AWS account?

--- a/Accion_Labs/SRE.md
+++ b/Accion_Labs/SRE.md
@@ -12,8 +12,10 @@
 8) What is the Linux command used for mounting a file system?
 9) How do you detect the root cause when an application goes down in the cloud?
 10) How do you respond when:
+
 - a) the master node goes down?
 - b) a worker/slave node goes down?
+
 11) How do you configure a VPC for high availability?
 12) Have you worked on scripting? if so which tool ? explain what you have implemented?
 13) Have you written Terraform code for deployments? If yes, can you explain the implementation?

--- a/Accion_Labs/SRE.md
+++ b/Accion_Labs/SRE.md
@@ -1,3 +1,20 @@
+---
+company: "Accion Labs"
+role: "SRE"
+tags:
+  - interview
+  - company/accion-labs
+  - role/sre
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ansible
+  - topic/linux
+  - topic/sre
+  - topic/scripting
+---
+
 # Accion Labs
 
 **Exp---17yrs SRE**

--- a/Accolite/DevOps_Engineer.md
+++ b/Accolite/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Accolite"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/accolite
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/ci-cd
+  - topic/monitoring
+  - topic/scripting
+  - topic/databases
+---
+
 # Accolite
 
 **Exp---- 3yr DevOps Engineer**

--- a/Akamai/SRE.md
+++ b/Akamai/SRE.md
@@ -1,3 +1,15 @@
+---
+company: "Akamai"
+role: "SRE"
+tags:
+  - interview
+  - company/akamai
+  - role/sre
+  - topic/linux
+  - topic/sre
+  - topic/networking
+---
+
 # Akamai
 
 **Exp---8yrs  SRE**

--- a/Alphadyne/DevOps_Engineer_1.md
+++ b/Alphadyne/DevOps_Engineer_1.md
@@ -1,3 +1,19 @@
+---
+company: "Alphadyne"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/alphadyne
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/networking
+  - topic/security
+---
+
 # Alphadyne
 
 **YOE---> 5 Years**

--- a/Alphadyne/DevOps_Engineer_2.md
+++ b/Alphadyne/DevOps_Engineer_2.md
@@ -1,3 +1,21 @@
+---
+company: "Alphadyne"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/alphadyne
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ansible
+  - topic/linux
+  - topic/monitoring
+  - topic/networking
+  - topic/databases
+---
+
 # Alphadyne
 
 **YOE-->**

--- a/Altimetrik/SRE.md
+++ b/Altimetrik/SRE.md
@@ -30,7 +30,6 @@
 
 - Question : What is what is an ideal burn rate?
 
-
 - Question : So how you are using terraform to deploy the cluster nodes?
 
 - Question : Set up the nodes and everything. what do you write inside a terraform code basically now what will be inside your provider file provided ATF in your main dotf?
@@ -38,9 +37,7 @@
 - Question : I'll give you an example like let's talk about AWS. You have you're going to create a VPC and subnet And your provider is AWS and I'm asking you to write in using terraform.
 - Like you have to deploy, you have to basically create VPC and map you have to create a subnet and you have to attach let's be the public or a private submit. It's of your choice to attach it to your VPC.
 
-
 - Question : You have optimized Kubernetes deployment configs. So can you explain me what have what was the role and what what have you done there?
-
 
 - Question : You mentioned about like the are you have architected a blameless postmortem framework, right? So for continuous learning, so how I mean what have you done to improve occurrence of critical incidents that you have mentioned in your resume.
 - You also mentioned about basically to reduce the MTTR so can you explain me what automation that you have done?

--- a/Altimetrik/SRE.md
+++ b/Altimetrik/SRE.md
@@ -1,3 +1,19 @@
+---
+company: "Altimetrik"
+role: "SRE"
+tags:
+  - interview
+  - company/altimetrik
+  - role/sre
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/gcp
+  - topic/sre
+  - topic/networking
+  - topic/security
+---
+
 # Altimetrik
 
 - Question : How do you import a resource into Terraform that was created manually in AWS or GCP? What command would you use?

--- a/Amadeus_Labs/SRE.md
+++ b/Amadeus_Labs/SRE.md
@@ -1,3 +1,16 @@
+---
+company: "Amadeus Labs"
+role: "SRE"
+tags:
+  - interview
+  - company/amadeus-labs
+  - role/sre
+  - topic/kubernetes
+  - topic/linux
+  - topic/sre
+  - topic/security
+---
+
 # Amadeus Labs
 
 **Exp-5yr SRE**

--- a/Amazon/DevOps_Consultant_1.md
+++ b/Amazon/DevOps_Consultant_1.md
@@ -1,3 +1,18 @@
+---
+company: "Amazon"
+role: "DevOps Consultant"
+interview: 1
+tags:
+  - interview
+  - company/amazon
+  - role/devops-consultant
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+---
+
 # Amazon
 
 **Exp-9years(Devops Consulatnt)**

--- a/Amazon/DevOps_Consultant_2.md
+++ b/Amazon/DevOps_Consultant_2.md
@@ -1,3 +1,20 @@
+---
+company: "Amazon"
+role: "DevOps Consultant"
+interview: 2
+tags:
+  - interview
+  - company/amazon
+  - role/devops-consultant
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/networking
+  - topic/security
+  - topic/scripting
+  - topic/databases
+---
+
 # Amazon
 
 **Exp--7 years ( DevOps Consultant)**

--- a/Arrise_Solutions/DevOps_Engineer.md
+++ b/Arrise_Solutions/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Arrise Solutions"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/arrise-solutions
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/linux
+  - topic/networking
+---
+
 # Arrise Solutions
 
 **Exp--7 yrs**

--- a/Aspire/DevOps_Engineer.md
+++ b/Aspire/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Aspire"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/aspire
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/git
+  - topic/security
+---
+
 # Aspire
 
 - Comapny - Aspire

--- a/BMW_TechWorks/DevOps_Engineer.md
+++ b/BMW_TechWorks/DevOps_Engineer.md
@@ -1,3 +1,15 @@
+---
+company: "BMW TechWorks"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/bmw-techworks
+  - role/devops-engineer
+  - topic/aws
+  - topic/ci-cd
+  - topic/security
+---
+
 # BMW TechWorks
 
 **YOE: 3-4yrs**

--- a/Belcan/DevOps_Engineer.md
+++ b/Belcan/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Belcan"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/belcan
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+---
+
 # Belcan
 
 **YOE-->9 yr**

--- a/Blue_Yonder/DevOps_Engineer.md
+++ b/Blue_Yonder/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Blue Yonder"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/blue-yonder
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/azure
+  - topic/ci-cd
+  - topic/security
+---
+
 # Blue Yonder
 
 - •    How do you use Azure Key vault's secrets in AKS?

--- a/CGI/DevOps_Engineer.md
+++ b/CGI/DevOps_Engineer.md
@@ -1,3 +1,19 @@
+---
+company: "CGI"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/cgi
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/security
+  - topic/databases
+---
+
 # CGI
 
 **YOE---> 4.1 yrs**

--- a/CGI/DevOps_Engineer.md
+++ b/CGI/DevOps_Engineer.md
@@ -2,7 +2,6 @@
 
 **YOE---> 4.1 yrs**
 
-
 - CI/CD & Jenkins
 - How did you reduce a pipeline from 1 hour to 20 minutes?
 - Write a checkout stage with Git credentials.

--- a/CMT/SRE.md
+++ b/CMT/SRE.md
@@ -1,3 +1,19 @@
+---
+company: "CMT"
+role: "SRE"
+tags:
+  - interview
+  - company/cmt
+  - role/sre
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/linux
+  - topic/monitoring
+  - topic/sre
+  - topic/networking
+---
+
 # CMT
 
 **Exp-  4-5 yrs(SRE)**

--- a/CTS/DevOps_Engineer_1.md
+++ b/CTS/DevOps_Engineer_1.md
@@ -1,3 +1,16 @@
+---
+company: "CTS"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/cts
+  - role/devops-engineer
+  - topic/terraform
+  - topic/networking
+  - topic/security
+---
+
 # CTS (Cognizant)
 
 - What is connection drain

--- a/CTS/DevOps_Engineer_1.md
+++ b/CTS/DevOps_Engineer_1.md
@@ -8,7 +8,6 @@
 - What is Az App Gateway and how it encrypt http/https traffic
 - App is down and throwing 503 err code, what steps should be taken
 
-
 - Also for question 4 is the answer the below?
 - Check the status of nginx/apache service that was used to host the web app
 - Check if any firewall/security group rules are blocking the flow of traffic

--- a/CTS/DevOps_Engineer_2.md
+++ b/CTS/DevOps_Engineer_2.md
@@ -1,3 +1,18 @@
+---
+company: "CTS"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/cts
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/networking
+---
+
 # CTS (Cognizant)
 
 **Exp->3-4yr**

--- a/CTS/DevOps_Engineer_3.md
+++ b/CTS/DevOps_Engineer_3.md
@@ -1,3 +1,19 @@
+---
+company: "CTS"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/cts
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/ansible
+  - topic/scripting
+---
+
 # CTS (Cognizant)
 
 **Exp----->**

--- a/Capgemini/DevOps_Engineer_1.md
+++ b/Capgemini/DevOps_Engineer_1.md
@@ -1,3 +1,19 @@
+---
+company: "Capgemini"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/capgemini
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/azure
+  - topic/ci-cd
+  - topic/git
+  - topic/security
+  - topic/databases
+---
+
 # Capgemini
 
 **Exp- 6+ yrs overall experience (considering 3 yrs in devops)**

--- a/Capgemini/DevOps_Engineer_2.md
+++ b/Capgemini/DevOps_Engineer_2.md
@@ -1,3 +1,18 @@
+---
+company: "Capgemini"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/capgemini
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ansible
+  - topic/security
+  - topic/databases
+---
+
 # Capgemini
 
 **Exp-9yrs Relevant(5yrs in devops)**

--- a/Capgemini/DevOps_Engineer_3.md
+++ b/Capgemini/DevOps_Engineer_3.md
@@ -2,7 +2,6 @@
 
 **exp----**
 
-
 - What is the difference between NAT Gateway and IGW?
 - If your pod is in Pending state, then what are your troubleshoot steps?
 - Can you tell me the difference between secondary RDS and read-only RDS?

--- a/Capgemini/DevOps_Engineer_3.md
+++ b/Capgemini/DevOps_Engineer_3.md
@@ -1,3 +1,18 @@
+---
+company: "Capgemini"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/capgemini
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/networking
+  - topic/databases
+---
+
 # Capgemini
 
 **exp----**

--- a/Cisco/DevOps_Engineer.md
+++ b/Cisco/DevOps_Engineer.md
@@ -1,3 +1,22 @@
+---
+company: "Cisco"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/cisco
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/monitoring
+  - topic/security
+  - topic/scripting
+---
+
 # Cisco
 
 **Exp--->6+**

--- a/Commonwealth_Bank/SRE_principal.md
+++ b/Commonwealth_Bank/SRE_principal.md
@@ -1,3 +1,14 @@
+---
+company: "Commonwealth Bank"
+role: "SRE principal"
+tags:
+  - interview
+  - company/commonwealth-bank
+  - role/sre-principal
+  - topic/sre
+  - topic/networking
+---
+
 # Commonwealth Bank
 
 **Exp-4-5 Yrs**

--- a/Commonwealth_Bank/SRE_principal.md
+++ b/Commonwealth_Bank/SRE_principal.md
@@ -7,10 +7,14 @@
 1) What is observability architecture? Can you explain it?
 2) What is DNS? When you type google.com. What exactly happening in the background?
 3) What is the difference between observability
+
 - and monitoring?
+
 4) When we have logs, why we need trace?
 5) How SLA, SLO are set in an application?
+
 - Don't give me the formula. Just explain it in from business prospective?
+
 6) How do you decide SLI in an application?
 7) Explain metrics, log and trace including all used tools?
 8) How observability will help in maintainingside reliability?

--- a/Deloitte/DevOps_Engineer_1.md
+++ b/Deloitte/DevOps_Engineer_1.md
@@ -1,3 +1,17 @@
+---
+company: "Deloitte"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/deloitte
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/networking
+  - topic/scripting
+---
+
 # Deloitte
 
 **Exp-:**

--- a/Deloitte/DevOps_Engineer_2.md
+++ b/Deloitte/DevOps_Engineer_2.md
@@ -1,3 +1,20 @@
+---
+company: "Deloitte"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/deloitte
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/security
+---
+
 # Deloitte
 
 **Exp-----> 4yrs(Linkedin)**

--- a/Deloitte/DevOps_Engineer_3.md
+++ b/Deloitte/DevOps_Engineer_3.md
@@ -1,3 +1,23 @@
+---
+company: "Deloitte"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/deloitte
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/git
+  - topic/scripting
+---
+
 # Deloitte
 
 **EXP- 5yrs**

--- a/Deloitte/DevOps_Engineer_4.md
+++ b/Deloitte/DevOps_Engineer_4.md
@@ -1,3 +1,17 @@
+---
+company: "Deloitte"
+role: "DevOps Engineer"
+interview: 4
+tags:
+  - interview
+  - company/deloitte
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+---
+
 # Deloitte
 
 **YOE-4 yrs**

--- a/EPAM/DevOps_Engineer_1.md
+++ b/EPAM/DevOps_Engineer_1.md
@@ -2,14 +2,16 @@
 
 **Exp--> 9 years devops -4yrs**
 
-
 1. How to Create and Use Custom Resources in Kubernetes
+
 - what are name spaces in k8s
 - what is difference between deployment and statefulset
+
 4. what is role based control access
 5. what is cluster auto scaler and horizontal auto scaling
 
 - Terraform:
+
 1. what is provider?
 2. how to manage state in terraform
 3. Do you store the data in statefile locally or remotely. What is the block you use while storing the statefile.
@@ -24,9 +26,14 @@
 12. direct connect in aws
 12. storage gateway in AWS
 13. VPC, NAT gateway,s3, route53, vpc peering,transit gateway, autoscaling group
+
 - Difference between sG and NACL
+
 14. wht is the difference beteen copy and add
+
 - difference between cmd and entrypoint
+
 16. what is run and exec command
 17. what contains inside vat and opt in linux.
+
 - writ a script to search a pattern as 'error' and warning in test.log file. store the pattern with error in one file and  'warning' in another file. pass test.log in the argument

--- a/EPAM/DevOps_Engineer_1.md
+++ b/EPAM/DevOps_Engineer_1.md
@@ -1,3 +1,17 @@
+---
+company: "EPAM"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/epam
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/linux
+---
+
 # EPAM
 
 **Exp--> 9 years devops -4yrs**

--- a/EPAM/DevOps_Engineer_2.md
+++ b/EPAM/DevOps_Engineer_2.md
@@ -1,3 +1,17 @@
+---
+company: "EPAM"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/epam
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/networking
+  - topic/security
+---
+
 # EPAM
 
 **Exp-----> 7 YOE - AWS DevOps Engineer**

--- a/EPAM/DevOps_Engineer_2.md
+++ b/EPAM/DevOps_Engineer_2.md
@@ -9,9 +9,13 @@
 - Diff type of instance profiles
 - AMI vs Snapshots
 - Development team changed the AMI configuration to ASG launch template, how will you make sure that the new version is deployed properly.
+
 170. 90.00.9/0 - Is Public IP or Private IP
+
 - How to find out if the provided IP is public or Private
+
 192. 90.90.88/12 - Is private or Host
+
 - TGW in AWS
 - Post connecting diff VPCs through TGW, I want to black the traffic of A to B and B to C, how to perform it
 - EC2 in a private subnet should receive inbound traffic, how to enable it ? → NOT NAT Gateway

--- a/EPAM/DevOps_Engineer_3.md
+++ b/EPAM/DevOps_Engineer_3.md
@@ -1,3 +1,21 @@
+---
+company: "EPAM"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/epam
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/gcp
+  - topic/ci-cd
+  - topic/security
+---
+
 # EPAM
 
 **Exp--6 year**

--- a/EXL_Service/DevOps_Engineer.md
+++ b/EXL_Service/DevOps_Engineer.md
@@ -1,3 +1,21 @@
+---
+company: "EXL Service"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/exl-service
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/git
+  - topic/monitoring
+  - topic/sre
+  - topic/networking
+  - topic/security
+---
+
 # EXL Service
 
 **YOE---> 5 yrs**

--- a/EXL_Service/DevOps_Engineer.md
+++ b/EXL_Service/DevOps_Engineer.md
@@ -2,12 +2,11 @@
 
 **YOE---> 5 yrs**
 
-
 - You are onboarding a new customer with 5 million+ users. How would you design the complete application architecture as a Solution Architect?
 - Explain your complete CI/CD pipeline from code commit to production deployment.
 - Explain your Git branching strategy. How do you deploy code from different branches to different environments?
 - If Git is already the source of truth, why do we need Argo CD? Why not deploy directly using the CI/CD pipeline with Helm or kubectl?
-- Explain the complete request flow when a user accesses www.ingress.com until the request reaches the application pod.
+- Explain the complete request flow when a user accesses <www.ingress.com> until the request reaches the application pod.
 - You need to expose an application internally without using a LoadBalancer or NodePort service. How would you do it?
 - Pods in different namespaces can communicate. How would you block that communication? Where would you implement the NetworkPolicy?
 - Suppose you are implementing a Canary deployment where only 10% of users receive the new version. How would you implement it through your CI/CD pipeline?

--- a/EY/DevOps_Engineer_1.md
+++ b/EY/DevOps_Engineer_1.md
@@ -1,3 +1,18 @@
+---
+company: "EY"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/ey
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/git
+  - topic/monitoring
+---
+
 # E&Y
 
 - Introduction

--- a/EY/DevOps_Engineer_2.md
+++ b/EY/DevOps_Engineer_2.md
@@ -1,3 +1,19 @@
+---
+company: "EY"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/ey
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/security
+---
+
 # E&Y
 
 **experienc---->**

--- a/Elixr_Labs/DevOps_Engineer.md
+++ b/Elixr_Labs/DevOps_Engineer.md
@@ -1,3 +1,15 @@
+---
+company: "Elixr Labs"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/elixr-labs
+  - role/devops-engineer
+  - topic/azure
+  - topic/ci-cd
+  - topic/monitoring
+---
+
 # Elixr Labs
 
 **Exp-----> 6yr**

--- a/Elixr_Labs/DevOps_Engineer.md
+++ b/Elixr_Labs/DevOps_Engineer.md
@@ -17,7 +17,9 @@
 14. IN which senario we will go for site-to-site vpn  and Expressroute
 15. any storage related components have u worked on?
 16. lets say i have a condition i need to access the data which is stored in storage account but that is huge data which is comming from enduser perspective lets say some cppotency that is recording 24/7 and data will be stored but at the same time if anyone comes and to retrieve the data obviously they will get it from storage account,now i need to implement some cost optimisation techniques on storage account to reduce cose because data to be incresed daytoday ?whta afre the possible ways
+
 - with respective storageaccount
+
 16. suppose u have created a storage accouunt with hot-tier is it possible to change to cool-tier
 17. manually we can change from hottier to cool tier ,but when i have huge data it will take time right .
 18. Did u face  any challenges while ur taking backup? any issues

--- a/Emphasis/DevOps_Engineer_1.md
+++ b/Emphasis/DevOps_Engineer_1.md
@@ -1,3 +1,19 @@
+---
+company: "Emphasis"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/emphasis
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+  - topic/security
+---
+
 # Emphasis
 
 - I attended interview for devops role, they were asking very basic questions about devops & aws.

--- a/Emphasis/DevOps_Engineer_2.md
+++ b/Emphasis/DevOps_Engineer_2.md
@@ -1,3 +1,19 @@
+---
+company: "Emphasis"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/emphasis
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/networking
+  - topic/databases
+---
+
 # Emphasis
 
 - What is AWS Lambda and how do you design a serverless application?

--- a/Encora/DevOps_Engineer.md
+++ b/Encora/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Encora"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/encora
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/security
+---
+
 # Encora
 
 **Exp---- 7 yrs**

--- a/F5/Associate_Consultant.md
+++ b/F5/Associate_Consultant.md
@@ -11,12 +11,16 @@
 - Difference between Transit gateway and VPC,
 - Best practices to be followed for cloud security.,
 - HTTP request header and HTTP Methods,
+
 10. If thre is an instance we have security group and web application firewall enabled, DDOS attack enabled will it protect from Bot attack.
+
 - There is db I made same entry(Name, Location) through PUT method twice what will happen.,
 - Why is PUT request called idempotency in nature. If I made another entry and name is same but location is differnet then what will db store.,
-- What happens if I type www.google.com in the background.,
+- What happens if I type <www.google.com> in the background.,
 - What is SSL/TLS Handshake.,
+
 15. What is DNS Resolution. Suppose I have new system with no cache what happens in the background.Step by step process.
+
 - What is K8. Explain the architecture.,
 - Can I run POD inside master-node itself?,
 - Have you deployed any security application on Kubernetes?

--- a/F5/Associate_Consultant.md
+++ b/F5/Associate_Consultant.md
@@ -1,3 +1,17 @@
+---
+company: "F5"
+role: "Associate Consultant"
+tags:
+  - interview
+  - company/f5
+  - role/associate-consultant
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/networking
+  - topic/security
+---
+
 # F5
 
 **Exp--(Associate Consultant )**

--- a/Five9/DevOps_Engineer.md
+++ b/Five9/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Five9"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/five9
+  - role/devops-engineer
+  - topic/aws
+  - topic/linux
+  - topic/monitoring
+  - topic/networking
+---
+
 # Five9
 
 **Exp---> 7 YOE**

--- a/Flentas/DevOps_Engineer.md
+++ b/Flentas/DevOps_Engineer.md
@@ -20,8 +20,10 @@
 12. What is the difference between a Pod and a Container?
 13. What are requests and limits in Kubernetes?
 14. One node has 8 vCPU and 32 GB RAM. With pod autoscaling up to 4 replicas, each pod having
+
 - limits of 4 vCPU / 16 GB and requests of 2 vCPU / 10 GB RAM, how many instances of the pod will
 - run?
+
 15. What did you implement in Lambda and API Gateway?
 16. What is the difference between Redis and Memcached?
 17. Explain the Terraform folder structure.
@@ -31,16 +33,22 @@
 21. When you ran terraform apply, did you encounter any unexpected changes?
 22. If there is a problem in Terraform, how will you roll back the changes?
 23. I have created an LB using Terraform, and some updates happened on it. Now I want to delete
+
 - the LB only — how will you do it?
+
 24. How do you handle secrets in Terraform?
 25. How will you pass secrets from AWS Secrets Manager to the pipeline?
 26. Do you commit the tfvars file to Git? While running the pipeline, these parameters need to be
+
 - filled — how do you manage this in Jenkins?
+
 27. What is Docker?
 28. What is the difference between an image and a container?
 29. What is a Helm chart?
 30. I want to enable autoscaling in Kubernetes during high traffic. How will you scale both cluster
+
 - nodes and pods?
+
 31. Can we use Cluster Autoscaler?
 32. How do you scale EC2 instances?
 33. When do we use VPA (Vertical Pod Autoscaler)?

--- a/Flentas/DevOps_Engineer.md
+++ b/Flentas/DevOps_Engineer.md
@@ -1,3 +1,21 @@
+---
+company: "Flentas"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/flentas
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/networking
+  - topic/databases
+---
+
 # Flentas
 
 **exp -----> 3.5 yrs**

--- a/HCL/DevOps_Engineer_1.md
+++ b/HCL/DevOps_Engineer_1.md
@@ -1,3 +1,20 @@
+---
+company: "HCL"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/hcl
+  - role/devops-engineer
+  - topic/docker
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/security
+---
+
 # HCL
 
 **exp--> 4-5**

--- a/HCL/DevOps_Engineer_2.md
+++ b/HCL/DevOps_Engineer_2.md
@@ -1,3 +1,19 @@
+---
+company: "HCL"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/hcl
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/monitoring
+---
+
 # HCL
 
 - what is diff between pv and pvc

--- a/HCL/DevOps_Engineer_3.md
+++ b/HCL/DevOps_Engineer_3.md
@@ -1,3 +1,18 @@
+---
+company: "HCL"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/hcl
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+---
+
 # HCL
 
 **exp ----- 5 yrs**

--- a/HCL/DevOps_Engineer_software.md
+++ b/HCL/DevOps_Engineer_software.md
@@ -1,3 +1,17 @@
+---
+company: "HCL"
+role: "DevOps Engineer software"
+tags:
+  - interview
+  - company/hcl
+  - role/devops-engineer-software
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/monitoring
+  - topic/security
+---
+
 # HCL
 
 **Exp---5 years**

--- a/Hexaware/DevOps_Engineer.md
+++ b/Hexaware/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Hexaware"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/hexaware
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+---
+
 # Hexaware
 
 **Exp--4-5yrs**

--- a/Hexaware/DevOps_Engineer.md
+++ b/Hexaware/DevOps_Engineer.md
@@ -15,5 +15,5 @@
 10. how do you moved the code from one environment to other environment
 11. what is variable group in azure devops
 12. what is sonarqube and which purpose it is used for
- 13. Write sample terraform code (overall skeleton)
+13. Write sample terraform code (overall skeleton)
 14. what are the files available inside helm chart

--- a/IBM/Cloud_Engineer.md
+++ b/IBM/Cloud_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "IBM"
+role: "Cloud Engineer"
+tags:
+  - interview
+  - company/ibm
+  - role/cloud-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ansible
+  - topic/security
+  - topic/scripting
+---
+
 # IBM
 
 **Exp-----> 3.3 Year exp**

--- a/IBM/DevOps_Engineer_1.md
+++ b/IBM/DevOps_Engineer_1.md
@@ -1,3 +1,19 @@
+---
+company: "IBM"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/ibm
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/networking
+---
+
 # IBM
 
 **Exp-7years (Devops Enginner)**

--- a/IBM/DevOps_Engineer_2.md
+++ b/IBM/DevOps_Engineer_2.md
@@ -1,3 +1,17 @@
+---
+company: "IBM"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/ibm
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/ci-cd
+---
+
 # IBM
 
 **Exp-->5yrs**

--- a/IBM/DevOps_Engineer_3.md
+++ b/IBM/DevOps_Engineer_3.md
@@ -1,3 +1,20 @@
+---
+company: "IBM"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/ibm
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+---
+
 # IBM
 
 **YOE: 5 +**

--- a/ITC_Infotech/DevOps_Engineer.md
+++ b/ITC_Infotech/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "ITC Infotech"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/itc-infotech
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/networking
+---
+
 # ITC Infotech
 
 **YOE-->4 yr**

--- a/Infinite_Solutions/DevOps_Engineer.md
+++ b/Infinite_Solutions/DevOps_Engineer.md
@@ -1,3 +1,13 @@
+---
+company: "Infinite Solutions"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/infinite-solutions
+  - role/devops-engineer
+  - topic/kubernetes
+---
+
 # Infinite Solutions
 
 **Exp-5 yeras**

--- a/Infosys/DevOps_Engineer_1.md
+++ b/Infosys/DevOps_Engineer_1.md
@@ -1,3 +1,19 @@
+---
+company: "Infosys"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/infosys
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/git
+  - topic/monitoring
+---
+
 # Infosys
 
 1. Introduce yourself

--- a/Infosys/DevOps_Engineer_1.md
+++ b/Infosys/DevOps_Engineer_1.md
@@ -3,7 +3,9 @@
 1. Introduce yourself
 2. git commands used in day to day activities
 3. write sample docker file
+
 - 4 write sample terraform resource file
+
 5. Difference between git rebase and git merge
 6. difference between cmd and entry point
 7. explain about Prometheus and grafana

--- a/Infosys/DevOps_Engineer_2.md
+++ b/Infosys/DevOps_Engineer_2.md
@@ -1,3 +1,20 @@
+---
+company: "Infosys"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/infosys
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/monitoring
+---
+
 # Infosys
 
 - Introduction

--- a/Infosys/DevOps_Engineer_3.md
+++ b/Infosys/DevOps_Engineer_3.md
@@ -2,7 +2,6 @@
 
 **YOE---> 3 yrs**
 
-
 - What is your day to day activities
 - How do you reduce docker image size
 - What is HPA and how do you implement it

--- a/Infosys/DevOps_Engineer_3.md
+++ b/Infosys/DevOps_Engineer_3.md
@@ -1,3 +1,19 @@
+---
+company: "Infosys"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/infosys
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/monitoring
+  - topic/security
+  - topic/scripting
+---
+
 # Infosys
 
 **YOE---> 3 yrs**

--- a/Infosys/SRE.md
+++ b/Infosys/SRE.md
@@ -1,3 +1,21 @@
+---
+company: "Infosys"
+role: "SRE"
+tags:
+  - interview
+  - company/infosys
+  - role/sre
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/ansible
+  - topic/sre
+  - topic/networking
+  - topic/security
+  - topic/scripting
+---
+
 # Infosys
 
 **Exp---> 5+**

--- a/Intact_Green_Services/DevOps_Engineer.md
+++ b/Intact_Green_Services/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Intact Green Services"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/intact-green-services
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+---
+
 # Intact Green Services
 
 **exp ----- 5 yrs**

--- a/JPMorgan/DevOps_Engineer_1.md
+++ b/JPMorgan/DevOps_Engineer_1.md
@@ -1,3 +1,18 @@
+---
+company: "JPMorgan"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/jpmorgan
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/monitoring
+  - topic/security
+  - topic/databases
+---
+
 # JPMorgan
 
 **Experience--**

--- a/JPMorgan/DevOps_Engineer_senior.md
+++ b/JPMorgan/DevOps_Engineer_senior.md
@@ -1,3 +1,22 @@
+---
+company: "JPMorgan"
+role: "DevOps Engineer senior"
+tags:
+  - interview
+  - company/jpmorgan
+  - role/devops-engineer-senior
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/monitoring
+  - topic/sre
+  - topic/networking
+  - topic/security
+  - topic/databases
+---
+
 # JPMorgan
 
 **Exp---> Senior DevOps Engineer**

--- a/JPMorgan/DevOps_SRE.md
+++ b/JPMorgan/DevOps_SRE.md
@@ -12,7 +12,9 @@
 6) If an application has only one replica and you perform a rolling restart, will there be downtime? Also what events occur during the pod restart can you explain the sequence step by step?
 7) You have an application with 2 replicas. During a rollout, the first pod is successfully replaced, but when the second pod is being replaced it enters a CrashLoopBackOff state. At that moment, which pod will the load balancer route traffic to the new pod, the old pod, or both? explain
 8) Just like we use code-quality and security checks (quality gates, OWASP) before building an image, how can we prevent insecure infrastructure changes from being pushed using terraform?
+
 - For example, if someone modifies a security group in Terraform and opens it to 0.0.0.0/0, what mechanisms can we use in Terraform to stop such changes from being applied?
+
 9) How would you handle Terraform state management for a team? Specifically, how would you store the tfstate file securely, make sure only one person can modify it at a time, and ensure the state is not tampered with? give me answers for all 3 qns
 10) You’ve joined a company where a large production infrastructure was built manually and the previous engineers have left. How would you bring that existing infrastructure under Terraform management? Walk me through your plan
 11) Are you aware of the recent AWS and Azure outages? What were your key takeaways from those incidents?

--- a/JPMorgan/DevOps_SRE.md
+++ b/JPMorgan/DevOps_SRE.md
@@ -1,3 +1,21 @@
+---
+company: "JPMorgan"
+role: "DevOps SRE"
+tags:
+  - interview
+  - company/jpmorgan
+  - role/devops-sre
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/ci-cd
+  - topic/monitoring
+  - topic/sre
+  - topic/networking
+  - topic/security
+---
+
 # JPMorgan
 
 **Exp-5years**

--- a/Koerber_Pharma/DevOps_Engineer.md
+++ b/Koerber_Pharma/DevOps_Engineer.md
@@ -1,3 +1,20 @@
+---
+company: "Koerber Pharma"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/koerber-pharma
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/monitoring
+  - topic/security
+---
+
 # Koerber Pharma
 
 **Exp --9 yrs Relevant (5 years)**

--- a/LTIMindtree/DevOps_Engineer_1.md
+++ b/LTIMindtree/DevOps_Engineer_1.md
@@ -1,3 +1,17 @@
+---
+company: "LTIMindtree"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/ltimindtree
+  - role/devops-engineer
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/jenkins
+---
+
 # LTIMindtree
 
 - Can we install docker inside a container.

--- a/LTIMindtree/DevOps_Engineer_2.md
+++ b/LTIMindtree/DevOps_Engineer_2.md
@@ -1,3 +1,18 @@
+---
+company: "LTIMindtree"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/ltimindtree
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/ansible
+  - topic/git
+---
+
 # LTIMindtree
 
 **Exp---5yrs**

--- a/LTIMindtree/DevOps_Engineer_3.md
+++ b/LTIMindtree/DevOps_Engineer_3.md
@@ -1,3 +1,18 @@
+---
+company: "LTIMindtree"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/ltimindtree
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/networking
+---
+
 # LTIMindtree
 
 **Exp---5 year**

--- a/LTIMindtree/DevOps_Engineer_4.md
+++ b/LTIMindtree/DevOps_Engineer_4.md
@@ -1,3 +1,20 @@
+---
+company: "LTIMindtree"
+role: "DevOps Engineer"
+interview: 4
+tags:
+  - interview
+  - company/ltimindtree
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/security
+  - topic/scripting
+---
+
 # LTIMindtree
 
 **Exp--->3 yrs**

--- a/LTIMindtree/DevOps_Engineer_L2.md
+++ b/LTIMindtree/DevOps_Engineer_L2.md
@@ -1,3 +1,15 @@
+---
+company: "LTIMindtree"
+role: "DevOps Engineer L2"
+tags:
+  - interview
+  - company/ltimindtree
+  - role/devops-engineer-l2
+  - topic/kubernetes
+  - topic/ci-cd
+  - topic/monitoring
+---
+
 # LTIMindtree
 
 **EXP 3-5 years. (L2)**

--- a/LTIMindtree/DevOps_Engineer_L2.md
+++ b/LTIMindtree/DevOps_Engineer_L2.md
@@ -13,6 +13,8 @@
 9. How do you secure sensitive data like passwords or API keys in infrastructure setups?
 10. How does your GitOps tool detect drift and how do you manage it?
 11. Write a script to monitor a service and restart it if it fails, including proper logging.
+
 - 12 .How do you handle parallel execution in CI/CD workflows?
+
 13. What’s the difference between using count and for_each in infrastructure code, and when should you use each?
 14. How do you monitor and alert on cloud resources effectively?

--- a/L_and_T/DevOps_Engineer.md
+++ b/L_and_T/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "L and T"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/l-and-t
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/ansible
+  - topic/git
+  - topic/security
+---
+
 # L&T
 
 **EXP-- 9years(4yrs in devops)**

--- a/Marsh_McLennan/DevOps_Engineer.md
+++ b/Marsh_McLennan/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Marsh McLennan"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/marsh-mclennan
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/security
+---
+
 # Marsh McLennan
 
 **YOE---> 3 yrs**

--- a/Moodys/MLOps_Engineer.md
+++ b/Moodys/MLOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Moodys"
+role: "MLOps Engineer"
+tags:
+  - interview
+  - company/moodys
+  - role/mlops-engineer
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+---
+
 # Moodys
 
 **YOE---->3-4 yrs**

--- a/Morgan_Stanley/Release_Engineer.md
+++ b/Morgan_Stanley/Release_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Morgan Stanley"
+role: "Release Engineer"
+tags:
+  - interview
+  - company/morgan-stanley
+  - role/release-engineer
+  - topic/kubernetes
+  - topic/linux
+  - topic/networking
+  - topic/scripting
+---
+
 # Morgan Stanley
 
 **EXP-- 7 YOE - Release engineer**

--- a/NPCI/DevOps_Engineer.md
+++ b/NPCI/DevOps_Engineer.md
@@ -1,3 +1,14 @@
+---
+company: "NPCI"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/npci
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+---
+
 # NPCI
 
 **Exp-----> 5yrs**

--- a/NPCI/DevOps_Engineer.md
+++ b/NPCI/DevOps_Engineer.md
@@ -8,6 +8,7 @@
 - Two containers are there. One with front end application and second container has db.Fisrt I want to start db then front end. What should you do?( 2tier application)
 - Kubernetes:
 - How do you call pod1 to pod2 without service.
+
 2. what is Container Network Interface
 3. what is CSI driver
 4. Static volume provisioning and dynamic volume provisioning. Explain in with use case.

--- a/NUOS_INFO_Systems/DevOps_Engineer.md
+++ b/NUOS_INFO_Systems/DevOps_Engineer.md
@@ -4,7 +4,6 @@
 
 - Tech stack— mainly around Terraform, Azure, DevOps, Docker, and Git
 
-
 - How do you scale a Terraform pipeline that takes 25+ mins?
 - What happens to the Terraform state file if someone deletes resources from Azure?
 - If the pipeline fails due to existing resources, how do you handle RIP (Remove, Import, Plan)?

--- a/NUOS_INFO_Systems/DevOps_Engineer.md
+++ b/NUOS_INFO_Systems/DevOps_Engineer.md
@@ -1,3 +1,21 @@
+---
+company: "NUOS INFO Systems"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/nuos-info-systems
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/ci-cd
+  - topic/git
+  - topic/monitoring
+  - topic/security
+---
+
 # NUOS INFO Systems
 
 **Exp--4yrs**

--- a/NatWest_Group/DevOps_Engineer.md
+++ b/NatWest_Group/DevOps_Engineer.md
@@ -1,3 +1,14 @@
+---
+company: "NatWest Group"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/natwest-group
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/linux
+---
+
 # NatWest Group
 
 - about Maven release

--- a/Netcracker/DevOps_Engineer.md
+++ b/Netcracker/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Netcracker"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/netcracker
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/linux
+  - topic/monitoring
+  - topic/networking
+---
+
 # Netcracker
 
 **Exp- 7 Years - DevOps role**

--- a/Nextturn/DevOps_Engineer.md
+++ b/Nextturn/DevOps_Engineer.md
@@ -1,3 +1,22 @@
+---
+company: "Nextturn"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/nextturn
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/monitoring
+  - topic/scripting
+---
+
 # Nextturn
 
 **YOE---**

--- a/Nice/SRE_1.md
+++ b/Nice/SRE_1.md
@@ -1,3 +1,18 @@
+---
+company: "Nice"
+role: "SRE"
+interview: 1
+tags:
+  - interview
+  - company/nice
+  - role/sre
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/monitoring
+---
+
 # Nice
 
 - Comapny - Nice

--- a/Nice/SRE_2.md
+++ b/Nice/SRE_2.md
@@ -1,3 +1,19 @@
+---
+company: "Nice"
+role: "SRE"
+interview: 2
+tags:
+  - interview
+  - company/nice
+  - role/sre
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/ci-cd
+  - topic/security
+---
+
 # Nice
 
 - Comapny - Nice

--- a/Nisum_Technologies/DevOps_Engineer.md
+++ b/Nisum_Technologies/DevOps_Engineer.md
@@ -1,3 +1,19 @@
+---
+company: "Nisum Technologies"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/nisum-technologies
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/ansible
+  - topic/security
+  - topic/scripting
+---
+
 # Nisum Technologies
 
 - explain CI/CD pipeline

--- a/Nitor_Infotech/DevOps_Engineer.md
+++ b/Nitor_Infotech/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Nitor Infotech"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/nitor-infotech
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/security
+---
+
 # Nitor Infotech
 
 **YOE-->6 yr**

--- a/Nitor_Infotech/DevOps_Engineer.md
+++ b/Nitor_Infotech/DevOps_Engineer.md
@@ -20,10 +20,12 @@
 16. How do you handle infrastructure code for multiple environments using terraform
 17. State locking in terraform
 18. Create a Deployment named web-app with:
+
 - Image: nginx:1.25
 - Replicas: 3
 - Container port: 80
 - Labels: app=web
+
 19. Write a nodeport service to expose the application on port 8080 for the above deployment
 20. Write a script to count how many processes are running under the user ubuntu.
 21. How have you implemented RBAC in your EKS setup

--- a/OPT_IT/DevOps_Engineer.md
+++ b/OPT_IT/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "OPT IT"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/opt-it
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/ci-cd
+  - topic/monitoring
+---
+
 # OPT IT
 
 **Exp:2+yrs**

--- a/One2N/DevOps_Engineer.md
+++ b/One2N/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "One2N"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/one2n
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/ci-cd
+  - topic/networking
+  - topic/databases
+---
+
 # One2N
 
 **YOE--->**

--- a/Optum/DevOps_Engineer.md
+++ b/Optum/DevOps_Engineer.md
@@ -1,3 +1,14 @@
+---
+company: "Optum"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/optum
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+---
+
 # Optum
 
 **Exp--->5 Yrs**

--- a/Oracle/DevOps_Engineer.md
+++ b/Oracle/DevOps_Engineer.md
@@ -1,3 +1,15 @@
+---
+company: "Oracle"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/oracle
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/linux
+---
+
 # Oracle
 
 **Experience - 8 years's**

--- a/Oracle/DevOps_Engineer_2.md
+++ b/Oracle/DevOps_Engineer_2.md
@@ -1,3 +1,15 @@
+---
+company: "Oracle"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/oracle
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/networking
+---
+
 # Oracle
 
 **Exp----7 YOE - DevOps Engineer**

--- a/Orion_Innovation/DevOps_Engineer.md
+++ b/Orion_Innovation/DevOps_Engineer.md
@@ -9,7 +9,9 @@
 5. you want to store the secrets in Jenkins pipeline , how will you do it
 6. application gateway TLS certificate is expired, what steps you will follow to renew it
 7. in Kuberenets there are 10 worker nodes, I have to deploy tomcat on each pods , how will you achieve it
+
 - I have an apache tomcat application running in k8 cluster, what are the manifests files you will be having inside in it
+
 9. application gateway is L7 or L4
 10. you have multiple VPC, how will you connect them in AWS
 11. an RDS is there in India region, I want to do read sync with RDS in London region, how will you implement it

--- a/Orion_Innovation/DevOps_Engineer.md
+++ b/Orion_Innovation/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Orion Innovation"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/orion-innovation
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/networking
+---
+
 # Orion Innovation
 
 **Exp---- 5yr DevOps Engineer**

--- a/Others/Cloud_Administrator_senior.md
+++ b/Others/Cloud_Administrator_senior.md
@@ -1,3 +1,16 @@
+---
+company: "Unknown"
+role: "Cloud Administrator senior"
+tags:
+  - interview
+  - role/cloud-administrator-senior
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/security
+---
+
 # Others
 
 **YOE-->6 yr**

--- a/Others/Cloud_Engineer.md
+++ b/Others/Cloud_Engineer.md
@@ -1,3 +1,13 @@
+---
+company: "Unknown"
+role: "Cloud Engineer"
+tags:
+  - interview
+  - role/cloud-engineer
+  - topic/aws
+  - topic/security
+---
+
 # Others
 
 - AWS Cloud Engineer role -:

--- a/Others/DevOps_Engineer_1.md
+++ b/Others/DevOps_Engineer_1.md
@@ -1,3 +1,24 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/ansible
+  - topic/linux
+  - topic/git
+  - topic/monitoring
+  - topic/security
+  - topic/scripting
+  - topic/databases
+---
+
 # Others
 
 - L1 Questions:

--- a/Others/DevOps_Engineer_10.md
+++ b/Others/DevOps_Engineer_10.md
@@ -1,3 +1,21 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 10
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/git
+  - topic/networking
+---
+
 # Others
 
 - Devops interview questions

--- a/Others/DevOps_Engineer_11.md
+++ b/Others/DevOps_Engineer_11.md
@@ -1,3 +1,20 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 11
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/ci-cd
+  - topic/monitoring
+  - topic/security
+  - topic/scripting
+---
+
 # Others
 
 - Self intro

--- a/Others/DevOps_Engineer_12.md
+++ b/Others/DevOps_Engineer_12.md
@@ -1,3 +1,23 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 12
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/git
+  - topic/networking
+  - topic/scripting
+---
+
 # Others
 
 - Total  - 4 Technical Round, 2F2F and 2 Virtual Round.

--- a/Others/DevOps_Engineer_12.md
+++ b/Others/DevOps_Engineer_12.md
@@ -2,7 +2,6 @@
 
 - Total  - 4 Technical Round, 2F2F and 2 Virtual Round.
 
-
 **Round 1: Technical Discussion (Client, Virtual)**
 
 1.  Tell me about yourself ?
@@ -25,8 +24,6 @@
 18. Some other questions related to BareMetal Server, Storage(HP, DELL) related.
 19. How would you optimize AWS resource costs? Can you explain the methods you would use ?
 
-
-
 **Round 2: Technical Manager Round (Internal, F2F)**
 
 1. Create Terraform S3 resources, and ensure that the resource is deleted automatically after 7 days ?
@@ -41,8 +38,6 @@
 9. What is the difference between Pod and Deployment in Kubernetes ?
 11. What are the services in Kubernetes have ?
 12. What would you recommend: NodePort Service or LoadBalancer Service in Kubernetes and why?
-
-
 
 **Round 3: Technical Round (Client, F2F)**
 

--- a/Others/DevOps_Engineer_13.md
+++ b/Others/DevOps_Engineer_13.md
@@ -1,3 +1,24 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 13
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/networking
+  - topic/security
+  - topic/scripting
+  - topic/databases
+---
+
 # Others
 
 - What is the difference between import and include in Ansible?

--- a/Others/DevOps_Engineer_14.md
+++ b/Others/DevOps_Engineer_14.md
@@ -1,3 +1,15 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 14
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/linux
+  - topic/scripting
+---
+
 # Others
 
 - k8s node pending state how to debug

--- a/Others/DevOps_Engineer_15.md
+++ b/Others/DevOps_Engineer_15.md
@@ -1,3 +1,21 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 15
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/monitoring
+  - topic/networking
+  - topic/scripting
+---
+
 # Others
 
 - Pod is running fine, all the parameters looks good, but the traffic is not reaching the pod when the user is trying to access the application, what could be the possible reason ?

--- a/Others/DevOps_Engineer_16.md
+++ b/Others/DevOps_Engineer_16.md
@@ -1,3 +1,21 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 16
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/gcp
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/linux
+  - topic/networking
+---
+
 # Others
 
 - Difference between build artificats and pipeline artifacts and which one is better

--- a/Others/DevOps_Engineer_2.md
+++ b/Others/DevOps_Engineer_2.md
@@ -1,3 +1,20 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/monitoring
+  - topic/networking
+  - topic/security
+---
+
 # Others
 
 - Whats ur organisation current cicd process and tools

--- a/Others/DevOps_Engineer_3.md
+++ b/Others/DevOps_Engineer_3.md
@@ -1,3 +1,19 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/linux
+  - topic/networking
+  - topic/security
+---
+
 # Others
 
 1. ) How many NAT Gateways are needed for two public & two private subnets n a single VPC? Min & max?

--- a/Others/DevOps_Engineer_3.md
+++ b/Others/DevOps_Engineer_3.md
@@ -12,5 +12,6 @@
 10. ) If the tfstate file is lost, what do you do? With & without backup?
 11. ) In Linux systems there is the term Load Average? what does that mean? how it is being calculated? and in what format the load average output is?
 12. ) One of your worker nodes is not joining the cluster. How would you debug the issue?
+
 - There were More Scenario Questions Related to "Load Balancers",
 - "Route 53", and "EKS and DB Automation and Administration"

--- a/Others/DevOps_Engineer_4.md
+++ b/Others/DevOps_Engineer_4.md
@@ -10,7 +10,6 @@
 - where do you use firewalls, SGs and NACLs
 - What are the best password security practices used by your organisation?
 
-
 - What are the security parameters we must consider while we are creating an EC2 instance for production?
 - How can you protect the data in an AWS instance?
 - How can you connect from AWS to on-prem servers?

--- a/Others/DevOps_Engineer_4.md
+++ b/Others/DevOps_Engineer_4.md
@@ -1,3 +1,17 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 4
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/git
+  - topic/security
+---
+
 # Others
 
 - how you ensure the best possible security for high availability architectures for 3 tier applications.

--- a/Others/DevOps_Engineer_5.md
+++ b/Others/DevOps_Engineer_5.md
@@ -1,3 +1,21 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 5
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/linux
+  - topic/monitoring
+  - topic/sre
+  - topic/networking
+  - topic/scripting
+---
+
 # Others
 
 1) What will happen if the k8 master node and worker node firewall gets broken? Will the existing deployments work or impact on any new deploymentsHow will you communicate to people

--- a/Others/DevOps_Engineer_5.md
+++ b/Others/DevOps_Engineer_5.md
@@ -15,6 +15,7 @@
 13) A sudden surge in traffic causes a web application to become unresponsive what will be the steps you will take to mitigate
 14) Design the deployment of the pod with replica set set as 3 and having apache httpd image running as a container.
 15) How do you reduce the size of Dockerfile
+
 - Write a shell script to find and delete all files in a directory that are older than 30 days.
 - Create a script to monitor the disk usage of a server. If usage exceeds 80%, log the details to a file and send an alert email.
 - Write a script that renames all .txt files in a directory by appending the current date to the filename.

--- a/Others/DevOps_Engineer_6.md
+++ b/Others/DevOps_Engineer_6.md
@@ -1,3 +1,17 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 6
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/azure
+  - topic/networking
+---
+
 # Others
 
 1) What is the difference between NSG and Firewall.

--- a/Others/DevOps_Engineer_7.md
+++ b/Others/DevOps_Engineer_7.md
@@ -1,3 +1,20 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 7
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/monitoring
+---
+
 # Others
 
 - Introduction

--- a/Others/DevOps_Engineer_8.md
+++ b/Others/DevOps_Engineer_8.md
@@ -1,3 +1,19 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 8
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/security
+---
+
 # Others
 
 - From one of the linkedin post >

--- a/Others/DevOps_Engineer_9.md
+++ b/Others/DevOps_Engineer_9.md
@@ -1,3 +1,21 @@
+---
+company: "Unknown"
+role: "DevOps Engineer"
+interview: 9
+tags:
+  - interview
+  - role/devops-engineer
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/security
+  - topic/scripting
+---
+
 # Others
 
 - /var partition is 90% full. What’s your immediate action?

--- a/Others/DevOps_Engineer_behavioral.md
+++ b/Others/DevOps_Engineer_behavioral.md
@@ -1,3 +1,13 @@
+---
+company: "Unknown"
+role: "DevOps Engineer behavioral"
+tags:
+  - interview
+  - role/devops-engineer-behavioral
+  - topic/ci-cd
+  - topic/security
+---
+
 # Others
 
 - Tell me about a time you handled a failed deployment in production. How did you manage the team and stakeholders?,

--- a/Others/SRE.md
+++ b/Others/SRE.md
@@ -4,7 +4,9 @@
 
 - Commands used for Kubernetes,Docker and Ansible..
 - Explain Kubernetes Structure, Config Map and Schedular..
+
 3. How do you troubleshoot Imagepull backoff error ?
+
 - Explain installation of prometheus and grafana..
 - Explain how you build CICD pipeline..
 - How we monitor cpu matrics in grafana?

--- a/Others/SRE.md
+++ b/Others/SRE.md
@@ -1,3 +1,17 @@
+---
+company: "Unknown"
+role: "SRE"
+tags:
+  - interview
+  - role/sre
+  - topic/kubernetes
+  - topic/docker
+  - topic/ci-cd
+  - topic/ansible
+  - topic/monitoring
+  - topic/sre
+---
+
 # Others
 
 - SRE role -:

--- a/Perfios/DevOps_Engineer.md
+++ b/Perfios/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Perfios"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/perfios
+  - role/devops-engineer
+  - topic/ci-cd
+  - topic/linux
+  - topic/networking
+  - topic/scripting
+---
+
 # Perfios
 
 **Exp-->4.7yrs**

--- a/Persistent_Systems/DevOps_Engineer_1.md
+++ b/Persistent_Systems/DevOps_Engineer_1.md
@@ -1,3 +1,17 @@
+---
+company: "Persistent Systems"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/persistent-systems
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+---
+
 # Persistent Systems
 
 **Exp---9YOE DevOps - 5YOE**

--- a/Persistent_Systems/DevOps_Engineer_2.md
+++ b/Persistent_Systems/DevOps_Engineer_2.md
@@ -1,3 +1,19 @@
+---
+company: "Persistent Systems"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/persistent-systems
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/monitoring
+  - topic/scripting
+---
+
 # Persistent Systems
 
 **Exp----13 YOE -rele- 5yr DevOps Engineer**

--- a/Persistent_Systems/DevOps_Engineer_3.md
+++ b/Persistent_Systems/DevOps_Engineer_3.md
@@ -1,3 +1,19 @@
+---
+company: "Persistent Systems"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/persistent-systems
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+  - topic/scripting
+---
+
 # Persistent Systems
 
 **exp -----> 5 yrs**

--- a/Persistent_Systems/DevOps_Engineer_4.md
+++ b/Persistent_Systems/DevOps_Engineer_4.md
@@ -1,3 +1,18 @@
+---
+company: "Persistent Systems"
+role: "DevOps Engineer"
+interview: 4
+tags:
+  - interview
+  - company/persistent-systems
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+---
+
 # Persistent Systems
 
 - With respect to DevOps, to set the CI/CD pipeline, which tools and services have you used?

--- a/Plansource_ValueLabs/DevOps_Engineer.md
+++ b/Plansource_ValueLabs/DevOps_Engineer.md
@@ -3,13 +3,18 @@
 1. how many subnets you can add to a VPC
 2. how to stream logs from docker conatiner to s3 from specific path within conatiner
 3. How you manage varibles in pipeline for terraform for different enevironments(dev/live/feture)
+
 - what happens when youe hit DNS from browser
 - difference between http and https
+
 6. difference between  Service  and Task in ecs
 7. how Autocaling happens in aws ECS
 8. how you scale  your EKS cluster based metrics/logs
+
 - difference between ALB and ELB and comes under which layer, when  to choose and why
 - How to spead up s3 upload with files in large size,  and client uploaded 10 Gb file but failed  after uploading 5 gb how you confirm that 5 gb is uploaded to s3
+
 11. how do  you optimize S3 cost
+
 - how do you make s3 secure  which is  have client sensitive  data
 - how autoscaing happens with ALB

--- a/Plansource_ValueLabs/DevOps_Engineer.md
+++ b/Plansource_ValueLabs/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Plansource ValueLabs"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/plansource-valuelabs
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+---
+
 # Plansource ValueLabs
 
 1. how many subnets you can add to a VPC

--- a/Publicis_Global_Delivery/DevOps_Engineer.md
+++ b/Publicis_Global_Delivery/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Publicis Global Delivery"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/publicis-global-delivery
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/databases
+---
+
 # Publicis Global Delivery
 
 **Exp--->**

--- a/Qburst/DevOps_Engineer.md
+++ b/Qburst/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Qburst"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/qburst
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/gcp
+---
+
 # Qburst
 
 **EXP-3-5 yrs**

--- a/Qentelli_Solutions/DevOps_Engineer.md
+++ b/Qentelli_Solutions/DevOps_Engineer.md
@@ -3,15 +3,25 @@
 **Exp-----> 5yrs**
 
 1. create s3 bucket with terraform
+
 - If developer sets private subnet to public, what should you do?
+
 3. KMS
+
 - ELB inflow and outflow
+
 5. How you maanage resources in terraform
+
 - write a shell script to backup logs last 7 days and remove older days.
+
 7. SG and NACL
+
 - How do you secure your environments in aws
+
 9. soft link and hard link
 10. user not able to get ssh, what are troubleshooting steps to perfrom
 11. what are metrics in cloudwatch you should focus on.
+
 - Your aws billing spikes, what should you check
+
 13. what are security options in aws

--- a/Qentelli_Solutions/DevOps_Engineer.md
+++ b/Qentelli_Solutions/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Qentelli Solutions"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/qentelli-solutions
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/linux
+  - topic/networking
+  - topic/security
+  - topic/scripting
+---
+
 # Qentelli Solutions
 
 **Exp-----> 5yrs**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Some companies show up more than once — different candidates, different rounds
 
 ## How it's organized
 
-```
+```text
 <Company Name>/
   DevOps_Engineer.md        (default when no specific role was mentioned)
   DevOps_Engineer_2.md      (second interview for the same company)
@@ -31,6 +31,28 @@ Search the repo for a company name, or open its folder directly. If you're prepp
 ## Contributing
 
 Have an interview experience worth sharing? Add it as a new file under the matching company folder (create the folder if it doesn't exist yet). Keep the one-file-per-interview format, and include the role and years of experience at the top if you can — it helps other candidates gauge relevance. If the company can't be named, put it under `Others/`.
+
+### Naming your file
+
+Use `<Role>.md`, with underscores instead of spaces — `DevOps_Engineer.md`, `SRE_principal.md`, `Cloud_Administrator_senior.md`. If a file for that role already exists in the folder, append the next number rather than merging into the existing one: `DevOps_Engineer_2.md`. Separate files preserve who was asked what, which is the point of the repo.
+
+### Formatting
+
+Markdown formatting is checked automatically on every pull request. The check only looks at files your PR touches, so you are never blocked by pre-existing issues elsewhere in the repo.
+
+Before pushing, run the auto-fixer from the repository root:
+
+```bash
+npx --yes markdownlint-cli2@0.23.2 --fix "**/*.md"
+```
+
+That resolves nearly everything — blank lines around lists, stray double blank lines, trailing whitespace, bare URLs. Rules that would rewrite list numbering are deliberately turned off in `.markdownlint-cli2.jsonc`, so the fixer will **not** renumber your questions.
+
+One rule can't auto-fix: `MD040` wants a language tag on every code fence. Use ```` ```bash ```` for commands, ```` ```yaml ```` for manifests, or ```` ```text ```` for plain output and diagrams.
+
+### Opening the PR
+
+A [pull request template](.github/PULL_REQUEST_TEMPLATE.md) is filled in for you when you open a PR. It asks for the company, role, and interview date, and has a short checklist covering the things that actually matter here: questions recorded as asked, no personal details about the interviewer, and the file in the right place.
 
 ## Support this
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ Each file is one interview experience. If a company was interviewed at more than
 
 Submissions that never named a company live under `Others/`.
 
+## Using this as an Obsidian vault
+
+Every interview file carries YAML frontmatter, so the repo can be opened directly as an Obsidian vault (`Open folder as vault` → point it at the repo root). Tags are nested, which means Obsidian's tag pane groups them into a browsable tree:
+
+```yaml
+---
+company: "Accion Labs"
+role: "SRE"
+interview: 2 # only present when it's the Nth interview for that role
+tags:
+  - interview
+  - company/accion-labs
+  - role/sre
+  - topic/kubernetes
+  - topic/terraform
+---
+```
+
+`topic/` tags are derived from what each file actually mentions. The vocabulary is fixed at 17 topics:
+
+`kubernetes`, `docker`, `terraform`, `aws`, `azure`, `gcp`, `ci-cd`, `jenkins`, `ansible`, `linux`, `git`, `monitoring`, `sre`, `networking`, `security`, `scripting`, `databases`
+
+Useful searches once the vault is open:
+
+```text
+tag:#topic/kubernetes tag:#topic/terraform    both topics in one interview
+tag:#company/amazon                           everything from one company
+tag:#role/sre -tag:#topic/aws                 SRE interviews that skip AWS
+```
+
+Files under `Others/` have `company: "Unknown"` and carry no `company/` tag, since those submissions never named the employer.
+
 ## Using this
 
 Search the repo for a company name, or open its folder directly. If you're prepping broadly rather than for one company, skim a handful of folders across different company sizes (product companies, service companies like TCS/Infosys/Wipro, fintech, etc.) — the range of questions tells you more than any single list.
@@ -33,6 +65,8 @@ Search the repo for a company name, or open its folder directly. If you're prepp
 Have an interview experience worth sharing? Add it as a new file under the matching company folder (create the folder if it doesn't exist yet). Keep the one-file-per-interview format, and include the role and years of experience at the top if you can — it helps other candidates gauge relevance. If the company can't be named, put it under `Others/`.
 
 ### Naming your file
+
+Add YAML frontmatter at the top of the file — `company`, `role`, and `tags` — following the schema in [Using this as an Obsidian vault](#using-this-as-an-obsidian-vault). Pick `topic/` tags only from the fixed 17-topic vocabulary listed there, and only for topics the interview actually covered.
 
 Use `<Role>.md`, with underscores instead of spaces — `DevOps_Engineer.md`, `SRE_principal.md`, `Cloud_Administrator_senior.md`. If a file for that role already exists in the folder, append the next number rather than merging into the existing one: `DevOps_Engineer_2.md`. Separate files preserve who was asked what, which is the point of the repo.
 

--- a/Rapidsoft/DevOps_Engineer.md
+++ b/Rapidsoft/DevOps_Engineer.md
@@ -1,3 +1,19 @@
+---
+company: "Rapidsoft"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/rapidsoft
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/databases
+---
+
 # Rapidsoft
 
 **Exp-: 10.5 years work ex. Devops. 4 -5 years of devops experience**

--- a/RelevantZ/DevOps_Engineer.md
+++ b/RelevantZ/DevOps_Engineer.md
@@ -1,3 +1,19 @@
+---
+company: "RelevantZ"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/relevantz
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/networking
+  - topic/security
+  - topic/databases
+---
+
 # RelevantZ
 
 - RelevantZ interview questions

--- a/RelevantZ/DevOps_Engineer.md
+++ b/RelevantZ/DevOps_Engineer.md
@@ -23,6 +23,8 @@
 15. suppose I want to communicate from subscription to another subscription, what are all the methods available to achieve it
 16. tell me some commands on kubernetes – how do you troubleshoot it
 17. what is terraform drift
+
 - there is data in ADF, data will not be constant always, it will be dynamic how do you get the data and analyse it and present (it can be done through pipeline too)
+
 19. what do you do with azure recovery service vault
 20. how do you take backups and explain some strategies which you had used

--- a/SAP/DevOps_Engineer.md
+++ b/SAP/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "SAP"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/sap
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+---
+
 # SAP
 
 **Exp---8yrs  Devops**

--- a/Sapient/DevOps_Engineer.md
+++ b/Sapient/DevOps_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Sapient"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/sapient
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/networking
+---
+
 # Sapient
 
 - Comapny - Sapient

--- a/Sigmoid/DevOps_Engineer_1.md
+++ b/Sigmoid/DevOps_Engineer_1.md
@@ -1,3 +1,14 @@
+---
+company: "Sigmoid"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/sigmoid
+  - role/devops-engineer
+  - topic/kubernetes
+---
+
 # Sigmoid
 
 **Exp---> 7 YOE DevOps Engineer**

--- a/Sigmoid/DevOps_Engineer_2.md
+++ b/Sigmoid/DevOps_Engineer_2.md
@@ -1,3 +1,19 @@
+---
+company: "Sigmoid"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/sigmoid
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/monitoring
+  - topic/networking
+  - topic/security
+  - topic/databases
+---
+
 # Sigmoid
 
 **Exp---> 7 YOE DevOps Engineer**

--- a/Sigmoid/DevOps_Engineer_3.md
+++ b/Sigmoid/DevOps_Engineer_3.md
@@ -1,3 +1,19 @@
+---
+company: "Sigmoid"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/sigmoid
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/linux
+  - topic/scripting
+---
+
 # Sigmoid
 
 **Exp---> 7 YOE**

--- a/Sigmoid/DevOps_Engineer_4.md
+++ b/Sigmoid/DevOps_Engineer_4.md
@@ -9,6 +9,7 @@
 3. What is the branching strategy that you follow in your org. Why did you follow this approach over other strategies.
 
 4. There is a new requirement from platform team to design a 3 tier architecture, with frontend , backend and database with all the security best practices , high availability , low latency. (AWS)
+
 - As a Devops engineer , you have to make a decision according to best and optimized solution for each component that you decide, like - should the db be run as statefullset or RDS/any cloud db managed solution is better, how do we deploy frontend-whether as pod or S3+cloudfront etc.
 
 5. During the explanation of architecture there were many counter and followup questions -
@@ -27,7 +28,6 @@
 6. Write a script to find a particular name in a file and replace it with another word.(can use bash or python) - they asked to execute as well
 7. Write a script to just find the first occurance of a pattern in the given file , and then extract the full line of the found pattern.(can use bash or python) - they asked to execute as well
 8. Write a script to find all the files in current directory and all subdirs,which are modified more than 5 hours ago, but not beyond today.
-
 
 - Round 2(F2F technical round with cloud devops architect):
 
@@ -52,9 +52,11 @@
 - Round 3 (F2F managerial + technical round):
 
 1. Explain the use of below linux commands:
+
 - finger,comm, netstat, jq, yq, at, atq, shuf, lsblk, less, last, nc, mtr, iftop, lsof, blkid, mkfs, nice
 
 2. Write a python script which takes a user input with any alphabet in capital (the user inp should be strictly alphabet and shouldn't be small letters).Then, from a given file, find min, max, sum from the corresponding numbers of the input alphabet. After printing the above details, delete all those matched lines from the file.
+
 - eg:
 - file.txt
 - C,23
@@ -77,7 +79,6 @@
 - Connection established from : 145.11.21.78
 
 - output should be: 145.11.21.78 , 189.22.99.19 , count=2
-
 
 4. Write a 3 stage Dockerfile with below scenario using pre-built images that they provided for each stage
    1. Set and copy the env config files , env variables , bash profiles like .bashrc , .bashprofile etc which already comes with image, to the 2nd stage

--- a/Sigmoid/DevOps_Engineer_4.md
+++ b/Sigmoid/DevOps_Engineer_4.md
@@ -1,3 +1,27 @@
+---
+company: "Sigmoid"
+role: "DevOps Engineer"
+interview: 4
+tags:
+  - interview
+  - company/sigmoid
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/monitoring
+  - topic/sre
+  - topic/networking
+  - topic/security
+  - topic/scripting
+  - topic/databases
+---
+
 # Sigmoid
 
 **Exp---> 4-7 YOE**

--- a/Sonata_Software/DevOps_Engineer_1.md
+++ b/Sonata_Software/DevOps_Engineer_1.md
@@ -1,3 +1,20 @@
+---
+company: "Sonata Software"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/sonata-software
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/monitoring
+  - topic/networking
+  - topic/databases
+---
+
 # Sonata Software
 
 **Exp---- 5yr DevOps Engineer**

--- a/Sonata_Software/DevOps_Engineer_1.md
+++ b/Sonata_Software/DevOps_Engineer_1.md
@@ -4,7 +4,9 @@
 
 1. what is the difference between application gateway and front door
 2. how do you protect your endpoints in AKS
+
 - what is the networking you are using in AKS
+
 4. how do you do cost optimization in cloud
 5. how do you implement to block an particular domain in application gateway
 6. how will write terraform module

--- a/Sonata_Software/DevOps_Engineer_2.md
+++ b/Sonata_Software/DevOps_Engineer_2.md
@@ -1,3 +1,17 @@
+---
+company: "Sonata Software"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/sonata-software
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/security
+  - topic/scripting
+---
+
 # Sonata Software
 
 **YOE: 6 +**

--- a/Sony/DevOps_Engineer.md
+++ b/Sony/DevOps_Engineer.md
@@ -1,6 +1,5 @@
 # Sony
 
-
 1. How would you respond to a production outage during peak hours?
 2. So how do you guarantee zero downtime deployments in Kubernetes.
 3. How do you decide to roll back or apply a hot‑fix when a production issue occurs?
@@ -13,6 +12,7 @@
 10. What steps do you take when monitoring metrics say the system is healthy but users are still complaining?
 11. How do you design alerting so that you avoid noisy or false alerts?
 12. How do you design alerting to avoid alert fatigue?
+
 - I want jenkins run pipeline once n number of commits are pushed how will you do that.
 - What are the vulnerability reports in your sonarqube.
 - If I want to start an ec2 instance once the cpu is utilised 80% what terraform code will you write and it also should copy the image from S3.

--- a/Sony/DevOps_Engineer.md
+++ b/Sony/DevOps_Engineer.md
@@ -1,3 +1,19 @@
+---
+company: "Sony"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/sony
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/monitoring
+  - topic/sre
+---
+
 # Sony
 
 1. How would you respond to a production outage during peak hours?

--- a/SquareOps/DevOps_Engineer.md
+++ b/SquareOps/DevOps_Engineer.md
@@ -1,3 +1,21 @@
+---
+company: "SquareOps"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/squareops
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/networking
+  - topic/security
+  - topic/databases
+---
+
 # SquareOps
 
 - 🏗️ Infrastructure & Architecture

--- a/Syncortex/Release_Engineer.md
+++ b/Syncortex/Release_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "Syncortex"
+role: "Release Engineer"
+tags:
+  - interview
+  - company/syncortex
+  - role/release-engineer
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ansible
+---
+
 # Syncortex
 
 **Exp---5yrs  Release engineer**

--- a/Synechron/DevOps_Engineer_1.md
+++ b/Synechron/DevOps_Engineer_1.md
@@ -1,3 +1,19 @@
+---
+company: "Synechron"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/synechron
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/azure
+  - topic/ci-cd
+  - topic/scripting
+---
+
 # Synechron
 
 **Exp----13 YOE - 5yr DevOps Engineer**

--- a/Synechron/DevOps_Engineer_2.md
+++ b/Synechron/DevOps_Engineer_2.md
@@ -1,3 +1,20 @@
+---
+company: "Synechron"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/synechron
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/linux
+  - topic/sre
+---
+
 # Synechron
 
 **Exp---- 3yr DevOps Engineer**

--- a/Synechron/DevOps_Engineer_3.md
+++ b/Synechron/DevOps_Engineer_3.md
@@ -5,6 +5,7 @@
 **Exp--4 year**
 
 - All the questions are scenario-based and counter questions. - I have remembered these question , all the counter questions into CICD related and Kubernets.
+
 1. Can you explain what CI/CD is and describe how you have implemented CI/CD pipelines in one of your projects?
 2. How does an AWS CodePipeline differ from a Jenkins pipeline? Can you give an example of when you would choose one over the other?
 3. How do you configure your CI/CD pipelines? Can you walk me through the steps you followed to set up a pipeline in a recent project?

--- a/Synechron/DevOps_Engineer_3.md
+++ b/Synechron/DevOps_Engineer_3.md
@@ -1,3 +1,19 @@
+---
+company: "Synechron"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/synechron
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/git
+  - topic/monitoring
+---
+
 # Synechron
 
 - Client -Morgan Stanley,

--- a/TCS/DevOps_Engineer_1.md
+++ b/TCS/DevOps_Engineer_1.md
@@ -1,3 +1,15 @@
+---
+company: "TCS"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/tcs
+  - role/devops-engineer
+  - topic/ansible
+  - topic/linux
+---
+
 # TCS
 
 **Exp -9 yrs devops rel-4yrs**

--- a/TCS/DevOps_Engineer_2.md
+++ b/TCS/DevOps_Engineer_2.md
@@ -1,3 +1,19 @@
+---
+company: "TCS"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/tcs
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/azure
+  - topic/ci-cd
+  - topic/ansible
+  - topic/security
+  - topic/scripting
+---
+
 # TCS
 
 **Exp-- 4-5 yrs (DEVOPS)**

--- a/TCS/SRE_1.md
+++ b/TCS/SRE_1.md
@@ -1,3 +1,19 @@
+---
+company: "TCS"
+role: "SRE"
+interview: 1
+tags:
+  - interview
+  - company/tcs
+  - role/sre
+  - topic/kubernetes
+  - topic/terraform
+  - topic/aws
+  - topic/ansible
+  - topic/linux
+  - topic/scripting
+---
+
 # TCS
 
 **EXP--->**

--- a/TCS/SRE_2.md
+++ b/TCS/SRE_2.md
@@ -1,3 +1,17 @@
+---
+company: "TCS"
+role: "SRE"
+interview: 2
+tags:
+  - interview
+  - company/tcs
+  - role/sre
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/databases
+---
+
 # TCS
 
 **EXP--->**

--- a/Techdome/DevOps_Engineer.md
+++ b/Techdome/DevOps_Engineer.md
@@ -1,3 +1,15 @@
+---
+company: "Techdome"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/techdome
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+---
+
 # Techdome
 
 1) Kubernetes architecture

--- a/Turning/Cloud_Engineer.md
+++ b/Turning/Cloud_Engineer.md
@@ -1,3 +1,15 @@
+---
+company: "Turning"
+role: "Cloud Engineer"
+tags:
+  - interview
+  - company/turning
+  - role/cloud-engineer
+  - topic/aws
+  - topic/ci-cd
+  - topic/git
+---
+
 # Turning
 
 **Exp---> Cloud Engineer**

--- a/UST/Cloud_Platform_Engineer.md
+++ b/UST/Cloud_Platform_Engineer.md
@@ -1,3 +1,16 @@
+---
+company: "UST"
+role: "Cloud Platform Engineer"
+tags:
+  - interview
+  - company/ust
+  - role/cloud-platform-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/scripting
+---
+
 # UST
 
 **EXP-3-5 yrs**

--- a/Verizon/DevOps_Engineer.md
+++ b/Verizon/DevOps_Engineer.md
@@ -1,3 +1,18 @@
+---
+company: "Verizon"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/verizon
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/linux
+  - topic/security
+  - topic/databases
+---
+
 # Verizon
 
 **Exp---3 years**

--- a/Verizon/DevOps_Engineer.md
+++ b/Verizon/DevOps_Engineer.md
@@ -3,7 +3,9 @@
 **Exp---3 years**
 
 1. what are the disadvantages of each deployment models in k8s
+
 - In k8s architecture which component is not running as pod
+
 3. k8s QOS (quality of service)
 4. disadvantage of using ebs volumes in eks
 5. Any reason why we cannot place our app pods in master node by default
@@ -13,20 +15,29 @@
 9. what version of k8s u used and did u perform any cluster upgrade
 10. how you switch between clusters tell me the command
 11. what is context in k8s
+
 - Etcd is sql or no sql database and reason
+
 13. init container and sidecar container
 14. liveness and readiness probes
 15. what is OOM and how to resolve OOM issue
 16. linux - hardlink vs softlink
 17. linux-  Cronjob
+
 - AWS secret manager vs parameter store
+
 19. docker run command -p represents port or publish
 20. linux is OS or kernel
 21. linux file hierarchy
+
 - Other ways to connect EC2 without pem key
 - Horizontal and vertical scaling RDS db steps
+
 24. Db RDS multiavailability vs read replicas
 25. how to delete old/untaged images in ECR
+
 - Types of variables in linux
+
 27. linux - kill vs kill -9 and total number of signals in linux
+
 - How to check linux process without use of ps or top command

--- a/Virtusa/Tech_Lead.md
+++ b/Virtusa/Tech_Lead.md
@@ -1,3 +1,18 @@
+---
+company: "Virtusa"
+role: "Tech Lead"
+tags:
+  - interview
+  - company/virtusa
+  - role/tech-lead
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/networking
+  - topic/scripting
+---
+
 # Virtusa
 
 **Exp---> Tech lead**

--- a/Volkswagen_Group_Digital/DevOps_Engineer.md
+++ b/Volkswagen_Group_Digital/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Volkswagen Group Digital"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/volkswagen-group-digital
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/azure
+  - topic/ci-cd
+  - topic/security
+---
+
 # Volkswagen Group Digital
 
 **YOE-->**

--- a/Volkswagen_Group_Digital/DevOps_Engineer.md
+++ b/Volkswagen_Group_Digital/DevOps_Engineer.md
@@ -4,6 +4,7 @@
 
 - ==
 - Looking for both DevOps (70%) and development (30%).
+
 1) How do you onboard a new project from code to release management with multiple environments like prod, QA, Dev.
 2) how do you automate all the steps in the CI and CD with lots of tools?
 3) how do you run security checks in docker image?

--- a/Wikreate_Media/DevOps_Engineer.md
+++ b/Wikreate_Media/DevOps_Engineer.md
@@ -1,3 +1,14 @@
+---
+company: "Wikreate Media"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/wikreate-media
+  - role/devops-engineer
+  - topic/aws
+  - topic/git
+---
+
 # Wikreate Media
 
 - Use of Route53

--- a/Wipro/DevOps_Engineer_1.md
+++ b/Wipro/DevOps_Engineer_1.md
@@ -1,3 +1,18 @@
+---
+company: "Wipro"
+role: "DevOps Engineer"
+interview: 1
+tags:
+  - interview
+  - company/wipro
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/azure
+  - topic/ci-cd
+  - topic/security
+---
+
 # Wipro
 
 - What is your day to day activity

--- a/Wipro/DevOps_Engineer_2.md
+++ b/Wipro/DevOps_Engineer_2.md
@@ -10,15 +10,21 @@
 - If clients reporting 504 Gateway Timeout errors. describe your approach to debugging the issue?
 - how would you implement optimistic locking a RESTful update endpoint to avoid lost updates?
 - if you were required to run pre-task checks, main tasks and post-task validation for patch automation, how would you structure your RedHat Automation & Virtulization scripts?
+
 7. Can you describe an approach to automating secure decommissioning of VMs, including data shredding.
 8. If you were required to maintain clarity in very large Ansible Inventories, what best practices should be followed when naming groups and hosts.
+
 - Describe the structure and advantage of using an Ansible role to manage a three-tier web application. what do you mean by three-tier web application?
 - if you have custom plugins that multiple roles depends on, how do you manage them in the context of Ansible Roles Management?
+
 11. What is Cloud-agnostic strategies? how do you leverage conditionals to make a role cloud-agnostic, particularly for environments like AWS, Azure and GCP.
+
 - How do you mitigate the risk of misscommunication when there are multi-lingual stakeholders involved in email threads?
 - How would you structure a multi-stage pipeline that builds, tests and deploys a containerized application to kubernetes using Github Actions.
 - How would you parameterize a workflow so that downstream jobs know which environment to deploy to?
+
 15. Describe the security implications of using Kubernetes secret in etcd without encryption?
+
 - How does Python's GIL affect multi-threaded web service performance and what alternatives exist to overcome it? what is Python's GIL affect multi-threaded web service?
 - How would you implement feature toggles in Deployment pipelines?
 - How would you schedule a task to run every 15 minutes in windows using powershell and linux with cron?

--- a/Wipro/DevOps_Engineer_2.md
+++ b/Wipro/DevOps_Engineer_2.md
@@ -1,3 +1,25 @@
+---
+company: "Wipro"
+role: "DevOps Engineer"
+interview: 2
+tags:
+  - interview
+  - company/wipro
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/azure
+  - topic/gcp
+  - topic/ci-cd
+  - topic/ansible
+  - topic/linux
+  - topic/monitoring
+  - topic/security
+  - topic/scripting
+---
+
 # Wipro
 
 **Exp--->7 years**

--- a/Wipro/DevOps_Engineer_3.md
+++ b/Wipro/DevOps_Engineer_3.md
@@ -1,3 +1,16 @@
+---
+company: "Wipro"
+role: "DevOps Engineer"
+interview: 3
+tags:
+  - interview
+  - company/wipro
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/networking
+  - topic/security
+---
+
 # Wipro
 
 **Exp--->4 years**

--- a/Wipro/DevOps_Engineer_3.md
+++ b/Wipro/DevOps_Engineer_3.md
@@ -15,5 +15,4 @@
 - Do career achievements always need to be big and complex, or can they also be simple improvements?
 - Is a service mesh always needed, or are alternative tools sometimes enough?
 
-
 - MiscImp Qst -:

--- a/Wipro/DevOps_Engineer_4.md
+++ b/Wipro/DevOps_Engineer_4.md
@@ -1,3 +1,17 @@
+---
+company: "Wipro"
+role: "DevOps Engineer"
+interview: 4
+tags:
+  - interview
+  - company/wipro
+  - role/devops-engineer
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+---
+
 # Wipro
 
 **YOE-->4 yr**

--- a/Wipro/DevOps_Engineer_5.md
+++ b/Wipro/DevOps_Engineer_5.md
@@ -1,3 +1,20 @@
+---
+company: "Wipro"
+role: "DevOps Engineer"
+interview: 5
+tags:
+  - interview
+  - company/wipro
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/git
+---
+
 # Wipro
 
 **EXP-9 yrs**

--- a/ZS_Associates/DevOps_Engineer.md
+++ b/ZS_Associates/DevOps_Engineer.md
@@ -1,3 +1,19 @@
+---
+company: "ZS Associates"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/zs-associates
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/networking
+  - topic/databases
+---
+
 # ZS Associates
 
 **YOE-->6 yr**

--- a/ZS_Associates/DevOps_Engineer.md
+++ b/ZS_Associates/DevOps_Engineer.md
@@ -5,7 +5,7 @@
 - Multi stage docker build. In which scenarios it would be useful. Is is suitable for compile based language?
 - Layer caching, explain with an example
 - Privileged mode in Docker. Explain with an example
-- Design an architecture for the scenario: if I type www.application.com it should get resolved to the backend service
+- Design an architecture for the scenario: if I type <www.application.com> it should get resolved to the backend service
 - Calico and VPC CNI plugin difference. Why one is preferred over other. How would they help in setting up networking for pod.
 - How is an ip address allocate to a pod. Does CNI plugin use same CIDR range which is provided by VPC or different?
 - Two pods which are part of same replica set are not able to communicate with each other what may be the reason

--- a/Zensar/DevOps_Engineer.md
+++ b/Zensar/DevOps_Engineer.md
@@ -1,3 +1,17 @@
+---
+company: "Zensar"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/zensar
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/azure
+  - topic/ci-cd
+  - topic/monitoring
+---
+
 # Zensar
 
 **Exp-:6+ years**

--- a/ZopSmart/DevOps_Engineer.md
+++ b/ZopSmart/DevOps_Engineer.md
@@ -1,3 +1,21 @@
+---
+company: "ZopSmart"
+role: "DevOps Engineer"
+tags:
+  - interview
+  - company/zopsmart
+  - role/devops-engineer
+  - topic/kubernetes
+  - topic/docker
+  - topic/terraform
+  - topic/aws
+  - topic/ci-cd
+  - topic/jenkins
+  - topic/ansible
+  - topic/linux
+  - topic/git
+---
+
 # ZopSmart
 
 **EXP-- 2yrs in devop**


### PR DESCRIPTION
---

# Pull Request / Branch Summary: `feature/update-interview-guides`

## 1. Overview & Goal
This update introduces repository-wide standardization for interview question guides, adds native **Obsidian vault support with structured metadata tags**, implements **automated PR linting/formatting checks**, and enhances documentation across 150+ interview guide files across 35+ company directories.

---

## 2. Key Enhancements

### 🏷️ Obsidian Vault & Structured YAML Metadata Support
* Added standardized **YAML frontmatter** to interview Markdown files (`company`, `role`, `interview` round index, and `tags`).
* Established a fixed **17-topic vocabulary** (`kubernetes`, `docker`, `terraform`, `aws`, `azure`, `gcp`, `ci-cd`, `jenkins`, `ansible`, `linux`, `git`, `monitoring`, `sre`, `networking`, `security`, `scripting`, `databases`).
* Enables the repository to be opened directly as an Obsidian vault (`Open folder as vault`), allowing tag-tree navigation and complex tag queries (e.g. `tag:#topic/kubernetes tag:#topic/terraform`).

### ⚙️ CI/CD & Code Quality Automation
* **New GitHub Action**: [markdown-lint.yml](file:///.github/workflows/markdown-lint.yml) runs on every pull request to automatically lint changed Markdown files using `markdownlint-cli2`.
* **Linting Config**: Created [.markdownlint-cli2.jsonc](file:///.markdownlint-cli2.jsonc). Custom rules were configured to ensure auto-fixing **preserves question list numbering** (`MD029`, `MD030`, `MD007` disabled), preventing content corruption while enforcing clean formatting (whitespace, blank lines, bare URLs, code block languages).
* **PR Template**: Added [.github/PULL_REQUEST_TEMPLATE.md](file:///.github/PULL_REQUEST_TEMPLATE.md) with a clear checklist covering contribution type, interview details, YAML frontmatter compliance, placement conventions, and formatting checks.

### 📖 Documentation & README Improvements
* Updated [README.md](file:///README.md) with detailed instructions on:
  * Using the repository as an Obsidian vault.
  * File naming & placement rules (`<Role>.md`, numbered sequences like `DevOps_Engineer_2.md`).
  * Formatting guidelines & running the local auto-fix command (`npx --yes markdownlint-cli2@0.23.2 --fix "**/*.md"`).
  * Submitting pull requests using the template.

### 📝 Interview Markdown Standardizations (35+ Directories)
* Formatted code blocks with language identifiers (e.g. `bash`, `yaml`, `text`).
* Cleaned up stray trailing whitespaces, unformatted inline links, and list block spacing across interview files for companies including:
  * *Accenture, Accion Labs, Accolite, Akamai, AMEX, Amazon, Capgemini, Cisco, Commonwealth Bank, Deloitte, EPAM, EY, F5, HCL, IBM, Infosys, JPMorgan, LTIMindtree, Oracle, TCS, Verizon, Wipro, ZS Associates, Others, and more.*

---

## 3. Directory-by-Directory Commit Breakdown

| Target Directory / File | Summary of Changes |
| :--- | :--- |
| `.github/`| Added PR template & GitHub Action workflow for PR markdown linting |
| `.markdownlint-cli2.jsonc` | Created markdownlint configuration tailored for ordered Q&A lists |
| `README.md` | Added Obsidian vault guide, tag schema, and contribution/formatting steps |
| `Accenture/` |  Metadata tag fixes and formatting updates in Accenture guides |
| `Accion_Labs/` | Formatting and topic tag alignment for SRE interview guide |
| `Altimetrik/` | Code fence formatting & list layout fixes |
| `Amazon/` | Standardized YAML frontmatter and formatting for DevOps Consultant roles |
| `CGI/` | Question listing & YAML header updates |
| `CTS/` | Updated 3 DevOps Engineer round files with topic tags |
| `Capgemini/` | Standardized formatting for Capgemini DevOps Engineer 1, 2, & 3 |
| `Deloitte/` | Updated 4 Deloitte interview files with standard tags & code blocks |
| `EPAM/` | Standardized 3 EPAM DevOps Engineer interview files |
| `EY/` | Added tags and cleaned up formatting in EY interview entries |
| `HCL/` | Updated 4 HCL interview guides with proper frontmatter |
| `IBM/` | Updated Cloud Engineer and DevOps Engineer 1, 2, 3 files |
| `Infosys/` | Standardized Infosys DevOps Engineer & SRE interview guides |
| `JPMorgan/` | Updated JPMorgan DevOps & SRE interview files |
| `LTIMindtree/` | Standardized 5 LTIMindtree interview entries |
| `Others/` | Standardized 20 unnamed interview entries under `Others/` (`company: "Unknown"`) |
| `TCS/` | Updated TCS DevOps Engineer & SRE files |
| `Wipro/` | Standardized 5 Wipro DevOps Engineer files |
| *(Other Companies)* | Standardized frontmatter, code blocks, and markdown rules across remaining directories |